### PR TITLE
Improved test coverage, removed access token method const

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -84,23 +84,6 @@ abstract class AbstractProvider implements ProviderInterface
     protected $httpBuildEncType = 1;
 
     /**
-     * Get the default scopes used by this provider.
-     *
-     * This should not be a complete list of all scopes, but the minimum
-     * required for the provider user interface!
-     *
-     * @return array
-     */
-    abstract protected function getDefaultScopes();
-
-    /**
-     * Returns the method to use when requesting an access token.
-     *
-     * @return string HTTP method
-     */
-    abstract protected function getAccessTokenMethod();
-
-    /**
      * @param array $options
      * @param array $collaborators
      */
@@ -263,6 +246,16 @@ abstract class AbstractProvider implements ProviderInterface
         return $generator->generateString($length);
     }
 
+    /**
+     * Get the default scopes used by this provider.
+     *
+     * This should not be a complete list of all scopes, but the minimum
+     * required for the provider user interface!
+     *
+     * @return array
+     */
+    abstract protected function getDefaultScopes();
+
     public function getAuthorizationUrl(array $options = [])
     {
         if (empty($options['state'])) {
@@ -307,6 +300,16 @@ abstract class AbstractProvider implements ProviderInterface
         header('Location: ' . $url);
         exit;
         // @codeCoverageIgnoreEnd
+    }
+
+    /**
+     * Returns the method to use when requesting an access token.
+     *
+     * @return string HTTP method
+     */
+    protected function getAccessTokenMethod()
+    {
+        return 'POST';
     }
 
     public function getAccessToken($grant = 'authorization_code', array $params = [])

--- a/src/Tool/RequestFactory.php
+++ b/src/Tool/RequestFactory.php
@@ -11,8 +11,6 @@ use GuzzleHttp\Psr7\Request;
  */
 class RequestFactory
 {
-    const DEFAULT_PROTOCOL_VERSION = '1.1';
-
     /**
      * Creates a PSR-7 Request instance.
      *
@@ -29,7 +27,7 @@ class RequestFactory
         $uri,
         array $headers = [],
         $body = null,
-        $version = self::DEFAULT_PROTOCOL_VERSION
+        $version = '1.1'
     ) {
         return new Request($method, $uri, $headers, $body, $version);
     }
@@ -47,7 +45,7 @@ class RequestFactory
         $defaults = [
             'headers' => [],
             'body'    => null,
-            'version' => self::DEFAULT_PROTOCOL_VERSION,
+            'version' => '1.1',
         ];
 
         return array_merge($defaults, $options);

--- a/src/Tool/RequestFactory.php
+++ b/src/Tool/RequestFactory.php
@@ -4,15 +4,24 @@ namespace League\OAuth2\Client\Tool;
 
 use GuzzleHttp\Psr7\Request;
 
-// For history see https://github.com/guzzle/guzzle/pull/1101
+/**
+ * Used to produce PSR-7 Request instances.
+ *
+ * @see https://github.com/guzzle/guzzle/pull/1101
+ */
 class RequestFactory
 {
+    const DEFAULT_PROTOCOL_VERSION = '1.1';
+
     /**
+     * Creates a PSR-7 Request instance.
+     *
      * @param  null|string $method HTTP method for the request.
      * @param  null|string $uri URI for the request.
-     * @param  array  $headers Headers for the message.
+     * @param  array $headers Headers for the message.
      * @param  string|resource|StreamInterface $body Message body.
-     * @param  string $protocolVersion HTTP protocol version.
+     * @param  string $version HTTP protocol version.
+     *
      * @return Request
      */
     public function getRequest(
@@ -20,36 +29,49 @@ class RequestFactory
         $uri,
         array $headers = [],
         $body = null,
-        $protocolVersion = '1.1'
+        $version = self::DEFAULT_PROTOCOL_VERSION
     ) {
-        return new Request($method, $uri, $headers, $body, $protocolVersion);
+        return new Request($method, $uri, $headers, $body, $version);
     }
 
     /**
-     * Get a request using a simplified array of options.
+     * Parses simplified options.
+     *
+     * @param array $options Simplified options.
+     *
+     * @return array Extended options for use with getRequest.
+     */
+    protected function parseOptions(array $options)
+    {
+        // Should match default values for getRequest
+        $defaults = [
+            'headers' => [],
+            'body'    => null,
+            'version' => self::DEFAULT_PROTOCOL_VERSION,
+        ];
+
+        return array_merge($defaults, $options);
+    }
+
+    /**
+     * Creates a request using a simplified array of options.
      *
      * @param  null|string $method
      * @param  null|string $uri
      * @param  array $options
+     *
      * @return Request
      */
     public function getRequestWithOptions($method, $uri, array $options = [])
     {
-        $func    = new \ReflectionMethod($this, 'getRequest');
-        $params  = $func->getParameters();
-        $options = array_replace($options, compact('method', 'uri'));
-        $args    = [];
+        $options = $this->parseOptions($options);
 
-        foreach ($params as $param) {
-            $name = $param->getName();
-            if (isset($options[$name])) {
-                $value = $options[$name];
-            } else {
-                $value = $param->getDefaultValue();
-            }
-            $args[$name] = $value;
-        }
-
-        return $func->invokeArgs($this, array_values($args));
+        return $this->getRequest(
+            $method,
+            $uri,
+            $options['headers'],
+            $options['body'],
+            $options['version']
+        );
     }
 }

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -267,27 +267,6 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertRegExp('/^[a-zA-Z0-9\/+]{32}$/', $qs['state']);
     }
 
-    public function testGetAccessTokenMethods()
-    {
-        $this->accessTokenTest('GET');
-        $this->accessTokenTest('POST');
-    }
-
-    /**
-     * @expectedException InvalidArgumentException
-     */
-    public function testInvalidAccessTokenMethod()
-    {
-        $provider = new MockProvider([
-          'clientId' => 'mock_client_id',
-          'clientSecret' => 'mock_secret',
-          'redirectUri' => 'none',
-        ]);
-
-        $provider->setAccessTokenMethod('PUT');
-        $provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
-    }
-
     public function testErrorResponsesCanBeCustomizedAtTheProvider()
     {
         $provider = new MockProvider([
@@ -494,5 +473,26 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($raw_response['uid'], $token->getUid());
         $this->assertSame($raw_response['access_token'], $token->getToken());
         $this->assertSame($raw_response['expires'], $token->getExpires());
+    }
+
+    public function testGetAccessTokenMethods()
+    {
+        $this->accessTokenTest('GET');
+        $this->accessTokenTest('POST');
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testInvalidAccessTokenMethod()
+    {
+        $provider = new MockProvider([
+          'clientId' => 'mock_client_id',
+          'clientSecret' => 'mock_secret',
+          'redirectUri' => 'none',
+        ]);
+
+        $provider->setAccessTokenMethod('PUT');
+        $provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
     }
 }

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -6,6 +6,7 @@ use League\OAuth2\Client\Provider\AbstractProvider;
 use League\OAuth2\Client\Token\AccessToken;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Test\Provider\Fake as MockProvider;
+use GuzzleHttp\Exception\BadResponseException;
 use Mockery as m;
 
 class AbstractProviderTest extends \PHPUnit_Framework_TestCase
@@ -328,15 +329,14 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         );
 
         $request = m::mock('Psr\Http\Message\RequestInterface');
+        $request->shouldReceive('getUri')->times(1)->andReturn('http://test');
 
         $response = m::mock('Psr\Http\Message\ResponseInterface');
         $response->shouldReceive('getBody')->times(1)->andReturn($stream);
+        $response->shouldReceive('getStatusCode')->times(3)->andReturn(403);
+        $response->shouldReceive('getReasonPhrase')->times(1)->andReturn('n/a');
 
-        $exception = m::mock('GuzzleHttp\Exception\BadResponseException', [
-            'message',
-            $request
-        ]);
-        $exception->shouldReceive('getResponse')->andReturn($response);
+        $exception = BadResponseException::create($request, $response);
 
         $method = $provider->getAccessTokenMethod();
         $url    = $provider->urlAccessToken();

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -415,7 +415,18 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(['example' => 'response'], $result);
     }
 
-    private function accessTokenTest($method)
+    public function getAccessTokenMethodProvider()
+    {
+        return [
+            ['GET'],
+            ['POST'],
+        ];
+    }
+
+    /**
+     * @dataProvider getAccessTokenMethodProvider
+     */
+    public function testGetAccessToken($method)
     {
         $provider = new MockProvider([
           'clientId' => 'mock_client_id',
@@ -473,12 +484,6 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($raw_response['uid'], $token->getUid());
         $this->assertSame($raw_response['access_token'], $token->getToken());
         $this->assertSame($raw_response['expires'], $token->getExpires());
-    }
-
-    public function testGetAccessTokenMethods()
-    {
-        $this->accessTokenTest('GET');
-        $this->accessTokenTest('POST');
     }
 
     /**

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -327,10 +327,15 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
             '{"error":"Foo error","code":1337}'
         );
 
+        $request = m::mock('Psr\Http\Message\RequestInterface');
+
         $response = m::mock('Psr\Http\Message\ResponseInterface');
         $response->shouldReceive('getBody')->times(1)->andReturn($stream);
 
-        $exception = m::mock('GuzzleHttp\Exception\BadResponseException');
+        $exception = m::mock('GuzzleHttp\Exception\BadResponseException', [
+            'message',
+            $request
+        ]);
         $exception->shouldReceive('getResponse')->andReturn($response);
 
         $method = $provider->getAccessTokenMethod();

--- a/test/src/Provider/Fake.php
+++ b/test/src/Provider/Fake.php
@@ -11,6 +11,8 @@ class Fake extends AbstractProvider
 {
     use BearerAuthorizationTrait;
 
+    private $accessTokenMethod = 'POST';
+
     public function urlAuthorize()
     {
         return 'http://example.com/oauth/authorize';
@@ -29,6 +31,16 @@ class Fake extends AbstractProvider
     protected function getDefaultScopes()
     {
         return ['test'];
+    }
+
+    public function setAccessTokenMethod($method)
+    {
+        $this->accessTokenMethod = $method;
+    }
+
+    public function getAccessTokenMethod()
+    {
+        return $this->accessTokenMethod;
     }
 
     protected function prepareUserDetails(array $response, AccessToken $token)


### PR DESCRIPTION
This pull request achieves the following:

 - Improved test coverage
 - Ability to test arbitrary access token request methods
 